### PR TITLE
Document how to use additional formats

### DIFF
--- a/docs/Usage.rst
+++ b/docs/Usage.rst
@@ -153,6 +153,29 @@ as an option (see end_date in the example).
 If both are specified then the moment format in options will take precedence.
 
 
+Customize DatePicker Format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to use arbitraty formats you must specify the pattern to the field's ``input_formats`` and the widget's ``format``.
+
+.. code-block:: python
+   :emphasize-lines: 11-12
+   
+    # File: forms.py
+    from bootstrap_datepicker_plus import DatePickerInput
+    from .models import Event
+    from django import forms
+
+    class ToDoForm(forms.Form):
+        todo = forms.CharField(
+            widget=forms.TextInput(attrs={"class": "form-control"})
+        )
+        date = forms.DateField(
+            input_formats=['%d/%m/%Y'],
+            widget=DatePickerInput(format='%d/%m/%Y')
+        )
+
+
 Customize the Language
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
# PR Description

The discussion at https://github.com/monim67/django-bootstrap-datepicker-plus/issues/15 is very useful. This PR adds the information to the docs.

## Purpose
There is still confusion on how to use custom formats.

## Approach
Documents usage.

#### Issues solved in this PR

#### What has Changed
- Add small example of non default date format
