### PR TITLE
Replaced obsolete ifequal/ifnotequal expressions

### DIFF
--- a/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/input.html
+++ b/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/input.html
@@ -1,1 +1,1 @@
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None and widget.value != "" %} value="{{ widget.value }}"{% endif %}{% for name, value in widget.attrs.items %}{% ifnotequal value False %} {{ name }}{% ifnotequal value True %}="{{ value|stringformat:'s' }}"{% endifnotequal %}{% endifnotequal %}{% endfor %}/>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None and widget.value != "" %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>

--- a/demo_project/demo_app/templates/layouts/nav-bar.html
+++ b/demo_project/demo_app/templates/layouts/nav-bar.html
@@ -1,19 +1,19 @@
 <div id="navbar" class="navbar-collapse collapse">
     <ul class="nav navbar-nav mr-auto">
-        <li class="nav-item {% ifequal url_sub_section 'custom-form' %}active{% endifequal %}">
+        <li class="nav-item {% if url_sub_section == 'custom-form' %}active{% endif %}">
             <a class="nav-link" href="custom-form.html">Custom Form</a>
         </li>
-        <li class="nav-item {% ifequal url_sub_section 'model-form-1' %}active{% endifequal %}">
+        <li class="nav-item {% if url_sub_section == 'model-form-1' %}active{% endif %}">
             <a class="nav-link" href="model-form-1.html">Model Form</a>
         </li>
     </ul>
     <ul class="nav navbar-nav navbar-right flex-row ml-md-auto d-none d-md-flex">
-        {% ifequal bootstrap_version 3 %}
+        {% if bootstrap_version == 3 %}
         <li class="nav-item"><a href="../bootstrap4/{{ url_sub_section }}.html">Switch to Bootstrap 4</a></li>
-        {% endifequal %}
-        {% ifequal bootstrap_version 4 %}
+        {% endif %}
+        {% if bootstrap_version == 4 %}
         <li class="nav-item"><a href="../bootstrap3/{{ url_sub_section }}.html">Switch to Bootstrap 3</a></li>
-        {% endifequal %}
+        {% endif %}
         <li class="nav-item"><a>Django {{ django_version_string }}</a></li>
     </ul>
 </div>


### PR DESCRIPTION
The ifequal/ifnotequal template expressions are obsolete and removed in Django main branch.