### PR TITLE
Expose djangoDatetimePicker as jQuery method

### DIFF
--- a/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/js/datepicker-widget.js
+++ b/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/js/datepicker-widget.js
@@ -1,55 +1,78 @@
-jQuery(function ($) {
+(function (factory) {
+  if (typeof define === 'function' && define.amd)
+    define(['jquery'], factory)
+  else if (typeof module === 'object' && module.exports)
+    module.exports = factory(require('jquery'))
+  else
+    factory(jQuery)
+}(function ($) {
     var datepickerDict = {};
-    var isBootstrap4 = $.fn.collapse.Constructor.VERSION.split('.').shift() == "4";
+    var isBootstrap4 = $.fn.collapse.Constructor.VERSION.split('.').shift() === "4";
     function fixMonthEndDate(e, picker) {
         e.date && picker.val().length && picker.val(e.date.endOf('month').format('YYYY-MM-DD'));
     }
-    $("[dp_config]:not([disabled])").each(function (i, element) {
+    function initOnePicker(element, options) {
         var $element = $(element), data = {};
         try {
             data = JSON.parse($element.attr('dp_config'));
         }
         catch (x) { }
+        $.extend(1, data.options, options);
         if (data.id && data.options) {
             data.$element = $element.datetimepicker(data.options);
             data.datepickerdata = $element.data("DateTimePicker");
-            datepickerDict[data.id] = data;
-            data.$element.next('.input-group-addon').on('click', function(){
+            data.$element.next('.input-group-addon').on('click', function() {
                 data.datepickerdata.show();
             });
-            if(isBootstrap4){
-                data.$element.on("dp.show", function (e) {
+            if (isBootstrap4) {
+                data.$element.on("dp.show", function(e) {
                     $('.collapse.in').addClass('show');
                 });
             }
         }
-    });
-    $.each(datepickerDict, function (id, to_picker) {
-        if (to_picker.linked_to) {
-            var from_picker = datepickerDict[to_picker.linked_to];
-            from_picker.datepickerdata.maxDate(to_picker.datepickerdata.date() || false);
-            to_picker.datepickerdata.minDate(from_picker.datepickerdata.date() || false);
-            from_picker.$element.on("dp.change", function (e) {
-                to_picker.datepickerdata.minDate(e.date || false);
+        return data;
+    };
+    function initLinkedPickers(to_picker) {
+        var from_picker = datepickerDict[to_picker.linked_to];
+        from_picker.datepickerdata.maxDate(to_picker.datepickerdata.date() || false);
+        to_picker.datepickerdata.minDate(from_picker.datepickerdata.date() || false);
+        from_picker.$element.on("dp.change", function (e) {
+            to_picker.datepickerdata.minDate(e.date || false);
+        });
+        to_picker.$element.on("dp.change", function (e) {
+            if (to_picker.picker_type == 'MONTH') fixMonthEndDate(e, to_picker.$element);
+            from_picker.datepickerdata.maxDate(e.date || false);
+        });
+        if (to_picker.picker_type == 'MONTH') {
+            to_picker.$element.on("dp.hide", function (e) {
+                fixMonthEndDate(e, to_picker.$element);
             });
-            to_picker.$element.on("dp.change", function (e) {
-                if (to_picker.picker_type == 'MONTH') fixMonthEndDate(e, to_picker.$element);
-                from_picker.datepickerdata.maxDate(e.date || false);
+            fixMonthEndDate({ date: to_picker.datepickerdata.date() }, to_picker.$element);
+        }
+    };
+    $.fn.djangoDatetimePicker = function(options){
+        options = options || {};
+        var newPickers = {};
+        $.each(this, function (i, element) {
+            var picker = initOnePicker($(element), options);
+            newPickers[picker.id] = picker;
+        });
+        $.extend(datepickerDict, newPickers);
+        $.each(newPickers, function (i, picker) {
+            if (picker.linked_to)
+                initLinkedPickers(picker);
+        });
+        return this;
+    }
+    $(function(){
+        $("[dp_config]:not([disabled])").djangoDatetimePicker();
+        if (isBootstrap4) {
+            $('body').on('show.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
+                $(e.target).addClass('in');
             });
-            if (to_picker.picker_type == 'MONTH') {
-                to_picker.$element.on("dp.hide", function (e) {
-                    fixMonthEndDate(e, to_picker.$element);
-                });
-                fixMonthEndDate({ date: to_picker.datepickerdata.date() }, to_picker.$element);
-            }
+            $('body').on('hidden.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
+                $(e.target).removeClass('in');
+            });
         }
     });
-    if(isBootstrap4) {
-        $('body').on('show.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
-            $(e.target).addClass('in');
-        });
-        $('body').on('hidden.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
-            $(e.target).removeClass('in');
-        });
-    }
-});
+}));

--- a/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/js/datepicker-widget.js
+++ b/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/js/datepicker-widget.js
@@ -1,78 +1,78 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd)
-    define(['jquery'], factory)
+  define(['jquery'], factory)
   else if (typeof module === 'object' && module.exports)
-    module.exports = factory(require('jquery'))
+  module.exports = factory(require('jquery'))
   else
-    factory(jQuery)
+  factory(jQuery)
 }(function ($) {
-    var datepickerDict = {};
-    var isBootstrap4 = $.fn.collapse.Constructor.VERSION.split('.').shift() === "4";
-    function fixMonthEndDate(e, picker) {
-        e.date && picker.val().length && picker.val(e.date.endOf('month').format('YYYY-MM-DD'));
+  var datepickerDict = {};
+  var isBootstrap4 = $.fn.collapse.Constructor.VERSION.split('.').shift() === "4";
+  function fixMonthEndDate(e, picker) {
+    e.date && picker.val().length && picker.val(e.date.endOf('month').format('YYYY-MM-DD'));
+  }
+  function initOnePicker(element, options) {
+    var $element = $(element), data = {};
+    try {
+      data = JSON.parse($element.attr('dp_config'));
     }
-    function initOnePicker(element, options) {
-        var $element = $(element), data = {};
-        try {
-            data = JSON.parse($element.attr('dp_config'));
-        }
-        catch (x) { }
-        $.extend(1, data.options, options);
-        if (data.id && data.options) {
-            data.$element = $element.datetimepicker(data.options);
-            data.datepickerdata = $element.data("DateTimePicker");
-            data.$element.next('.input-group-addon').on('click', function() {
-                data.datepickerdata.show();
-            });
-            if (isBootstrap4) {
-                data.$element.on("dp.show", function(e) {
-                    $('.collapse.in').addClass('show');
-                });
-            }
-        }
-        return data;
-    };
-    function initLinkedPickers(to_picker) {
-        var from_picker = datepickerDict[to_picker.linked_to];
-        from_picker.datepickerdata.maxDate(to_picker.datepickerdata.date() || false);
-        to_picker.datepickerdata.minDate(from_picker.datepickerdata.date() || false);
-        from_picker.$element.on("dp.change", function (e) {
-            to_picker.datepickerdata.minDate(e.date || false);
+    catch (x) { }
+    $.extend(1, data.options, options);
+    if (data.id && data.options) {
+      data.$element = $element.datetimepicker(data.options);
+      data.datepickerdata = $element.data("DateTimePicker");
+      data.$element.next('.input-group-addon').on('click', function() {
+        data.datepickerdata.show();
+      });
+      if (isBootstrap4) {
+        data.$element.on("dp.show", function(e) {
+          $('.collapse.in').addClass('show');
         });
-        to_picker.$element.on("dp.change", function (e) {
-            if (to_picker.picker_type == 'MONTH') fixMonthEndDate(e, to_picker.$element);
-            from_picker.datepickerdata.maxDate(e.date || false);
-        });
-        if (to_picker.picker_type == 'MONTH') {
-            to_picker.$element.on("dp.hide", function (e) {
-                fixMonthEndDate(e, to_picker.$element);
-            });
-            fixMonthEndDate({ date: to_picker.datepickerdata.date() }, to_picker.$element);
-        }
-    };
-    $.fn.djangoDatetimePicker = function(options){
-        options = options || {};
-        var newPickers = {};
-        $.each(this, function (i, element) {
-            var picker = initOnePicker($(element), options);
-            newPickers[picker.id] = picker;
-        });
-        $.extend(datepickerDict, newPickers);
-        $.each(newPickers, function (i, picker) {
-            if (picker.linked_to)
-                initLinkedPickers(picker);
-        });
-        return this;
+      }
     }
-    $(function(){
-        $("[dp_config]:not([disabled])").djangoDatetimePicker();
-        if (isBootstrap4) {
-            $('body').on('show.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
-                $(e.target).addClass('in');
-            });
-            $('body').on('hidden.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
-                $(e.target).removeClass('in');
-            });
-        }
+    return data;
+  };
+  function initLinkedPickers(to_picker) {
+    var from_picker = datepickerDict[to_picker.linked_to];
+    from_picker.datepickerdata.maxDate(to_picker.datepickerdata.date() || false);
+    to_picker.datepickerdata.minDate(from_picker.datepickerdata.date() || false);
+    from_picker.$element.on("dp.change", function (e) {
+      to_picker.datepickerdata.minDate(e.date || false);
     });
+    to_picker.$element.on("dp.change", function (e) {
+      if (to_picker.picker_type == 'MONTH') fixMonthEndDate(e, to_picker.$element);
+      from_picker.datepickerdata.maxDate(e.date || false);
+    });
+    if (to_picker.picker_type == 'MONTH') {
+      to_picker.$element.on("dp.hide", function (e) {
+        fixMonthEndDate(e, to_picker.$element);
+      });
+      fixMonthEndDate({ date: to_picker.datepickerdata.date() }, to_picker.$element);
+    }
+  };
+  $.fn.djangoDatetimePicker = function(options){
+    options = options || {};
+    var newPickers = {};
+    $.each(this, function (i, element) {
+      var picker = initOnePicker($(element), options);
+      newPickers[picker.id] = picker;
+    });
+    $.extend(datepickerDict, newPickers);
+    $.each(newPickers, function (i, picker) {
+      if (picker.linked_to)
+        initLinkedPickers(picker);
+    });
+    return this;
+  }
+  $(function(){
+    $("[dp_config]:not([disabled])").djangoDatetimePicker();
+    if (isBootstrap4) {
+      $('body').on('show.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
+        $(e.target).addClass('in');
+      });
+      $('body').on('hidden.bs.collapse','.bootstrap-datetimepicker-widget .collapse',function(e){
+        $(e.target).removeClass('in');
+      });
+    }
+  });
 }));


### PR DESCRIPTION
# PR Description
Simplify initialization of dynamically created inputs with jQuery convenience method.

## Purpose
Added delayed initialization of pickers. It's useful when new inputs are added dynamically (fetched from ajax or created during DOM manipulation, for instance). 

## Approach
In current state we can only do jQuery.getScript(...) or copy code by hands. The former is really not convenient and requires additional http request and having static url somewhere in js code, the latter breaks DRY principle. This PR creates jQuery method djangoDatetimePicker which can be later called on input. Options parameter can be used to add options without manipulations with dp_config attribute and have higher priority (allows override).

#### Issues solved in this PR

#### What has Changed
- Created jQuery.djangoDatetimePicker(options) method