### PR TITLE
Avoid redefining Bootstrap CSS class .glyphicon

### DIFF
--- a/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/css/datepicker-widget.css
+++ b/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/css/datepicker-widget.css
@@ -8,7 +8,7 @@
      url('//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 
-.glyphicon {
+.bootstrap-datapicker-glyphicon {
     position: relative;
     top: 1px;
     display: inline-block;

--- a/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/date-picker.html
+++ b/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/date-picker.html
@@ -1,6 +1,6 @@
 <div class="input-group date">
   {% include "bootstrap_datepicker_plus/input.html" %}
   <div class="input-group-addon input-group-append input-group-text">
-    <i class="glyphicon glyphicon-calendar"></i>
+    <i class="bootstrap-datapicker-glyphicon glyphicon-calendar"></i>
   </div>
 </div>

--- a/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/time-picker.html
+++ b/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/time-picker.html
@@ -1,6 +1,6 @@
 <div class="input-group date">
   {% include "bootstrap_datepicker_plus/input.html" %}
   <div class="input-group-addon input-group-append input-group-text">
-    <i class="glyphicon glyphicon-time"></i>
+    <i class="bootstrap-datapicker-glyphicon glyphicon-time"></i>
   </div>
 </div>

--- a/dev/myapp/templates/myapp/custom_input/date-picker.html
+++ b/dev/myapp/templates/myapp/custom_input/date-picker.html
@@ -2,6 +2,6 @@
 <div class="input-group date my-custom-class">
     {% include "bootstrap_datepicker_plus/input.html" %}
     <div class="input-group-addon input-group-append">
-        <div class="input-group-text"><i class="glyphicon glyphicon-calendar"></i></div>
+        <div class="input-group-text"><i class="bootstrap-datapicker-glyphicon glyphicon-calendar"></i></div>
     </div>
 </div>

--- a/dev/myapp/templates/myapp/custom_input/time-picker.html
+++ b/dev/myapp/templates/myapp/custom_input/time-picker.html
@@ -2,6 +2,6 @@
 <div class="input-group date my-custom-class">
     {% include "bootstrap_datepicker_plus/input.html" %}
     <div class="input-group-addon input-group-append">
-        <div class="input-group-text"><i class="glyphicon glyphicon-time"></i></div>
+        <div class="input-group-text"><i class="bootstrap-datapicker-glyphicon glyphicon-time"></i></div>
     </div>
 </div>

--- a/docs/Template_Customizing.rst
+++ b/docs/Template_Customizing.rst
@@ -30,7 +30,7 @@ Now you have to create a HTML template for date-picker input.
     <div class="input-group date my-custom-class">
         {% include "bootstrap_datepicker_plus/input.html" %}
         <div class="input-group-addon input-group-append">
-            <div class="input-group-text"><i class="glyphicon glyphicon-calendar"></i></div>
+            <div class="input-group-text"><i class="bootstrap-datapicker-glyphicon glyphicon-calendar"></i></div>
         </div>
     </div>
 
@@ -44,6 +44,6 @@ You can also create a template for TimePickerInput and create a custom time-pick
     <div class="input-group date my-custom-class">
         {% include "bootstrap_datepicker_plus/input.html" %}
         <div class="input-group-addon input-group-append">
-            <div class="input-group-text"><i class="glyphicon glyphicon-time"></i></div>
+            <div class="input-group-text"><i class="bootstrap-datapicker-glyphicon glyphicon-time"></i></div>
         </div>
     </div>


### PR DESCRIPTION
# PR Description

## Purpose
_Avoid redfining Bootstrap CSS class `.glyphicon`._

## Approach
_Used `bootstrap-datapicker-glyphicon` instead of `glyphicon`._

#### Issues solved in this PR
- [x] Issue #79

#### What has Changed
- Used `bootstrap-datapicker-glyphicon` instead of `glyphicon`
