### PR TITLE
fix: restrict pydantic < v2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 Django = ">=2,<5"
-pydantic = "*"
+pydantic = "<2"
 typing-extensions = "*"
 
 [tool.poetry.group.build.dependencies]


### PR DESCRIPTION
# PR Description

Make sure that pydantic version is less than v2.0 to prevent incompatibilities.

## Purpose
Fixes #99 by making sure that pydantic is not v2.0 or higher.

## Approach
Simple temporary fix until project can be made compatible with breaking changes in v2.0.

#### Issues solved in this PR
- [x] #99

#### What has Changed
- No functional changes, only keeps a working system working. Template.