### PR TITLE
PEP8: Avoid bare exceptions

### DIFF
--- a/src/bootstrap_datepicker_plus/settings.py
+++ b/src/bootstrap_datepicker_plus/settings.py
@@ -7,7 +7,7 @@ from django.conf import settings as django_settings
 try:
     from pydantic import Field, validator
     from pydantic.env_settings import BaseSettings, SettingsSourceCallable
-except:  # pragma: no cover
+except ImportError:
     from pydantic.v1.env_settings import BaseSettings, SettingsSourceCallable  # type: ignore
     from pydantic.v1 import Field, validator  # type: ignore
 


### PR DESCRIPTION
* https://realpython.com/the-most-diabolical-python-antipattern
* https://docs.astral.sh/ruff/rules/bare-except

# PR Description

## Purpose
We have a bare exception.

From PEP8:
> When catching exceptions, mention specific exceptions whenever possible instead of using a bare `except:` clause:
> 
> ```python
> try:
>    import platform_specific_module
> except ImportError:
>    platform_specific_module = None
> ```
>
> A bare `except:` clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems. If you want to catch all exceptions that signal program errors, use `except Exception:` (bare except is equivalent to `except BaseException:`).

## Approach
_How does this change address the problem?_

Fix the bare exception as recommended in PEP8.

#### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request-template) Github Repo with Learning focused Pull Request Template.