### PR TITLE
Restrict Pydantic dependency to version 1.x or 2.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1490,4 +1490,4 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8ceb1f79207794731e68c64ce85cc3255f023fc0bf9574ce0ed432fc93f13814"
+content-hash = "4b4de828f3586776203a8f8d3603f998f78bc73211150335e8f1b188411de630"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 Django = ">=2,<6"
-pydantic = "*"
+pydantic = ">=1,<3"
 typing-extensions = "^4.5"
 
 [tool.poetry.group.build.dependencies]


### PR DESCRIPTION
# PR Description

## Purpose
The `json()` method was renamed to `model_dump_json()` in Pydantic 2.0. The old name is still supported in Pydantic 2.x, but is scheduled for removal in Pydantic 3.0.

[Revelant docs.](https://docs.pydantic.dev/2.5/migration/#changes-to-pydanticbasemodel)

## Approach
To prevent the date picker breaking when Pydantic 3.0 is released, the declared Pydantic dependency is limited to versions 1.x and 2.x.

#### Issues solved in this PR
- [x] #113

#### What has Changed
- update dependency declaration in `pyproject.toml`
- regenerate content hash for `poetry.lock` (locked versions not changed)
