### PR TITLE
Set the addon_icon_class context on the widget key

### DIFF
--- a/src/bootstrap_datepicker_plus/_base.py
+++ b/src/bootstrap_datepicker_plus/_base.py
@@ -78,7 +78,7 @@ class BasePickerInput(DateTimeBaseInput):
         """Return widget context dictionary."""
         settings = get_widget_settings()
         context = super().get_context(name, value, attrs)
-        context["addon_icon_class"] = settings.addon_icon_classes[self.variant]
+        context["widget"]["addon_icon_class"] = settings.addon_icon_classes[self.variant]
         return context
 
     @deprecated(

--- a/src/bootstrap_datepicker_plus/settings.py
+++ b/src/bootstrap_datepicker_plus/settings.py
@@ -48,7 +48,7 @@ class WidgetSettings(BaseSettings):  # pyright: ignore
     bootstrap_icon_css_url: Optional[str] = (
         "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css"
     )
-    app_static_url = "https://cdn.jsdelivr.net/gh/monim67/django-bootstrap-datepicker-plus@5.0.6/src/bootstrap_datepicker_plus/static/bootstrap_datepicker_plus/"
+    app_static_url = "/static/bootstrap_datepicker_plus/"
     debug: bool = Field(default_factory=lambda: getattr(django_settings, "DEBUG", True))
 
     @validator("addon_icon_classes")

--- a/src/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/input.html
+++ b/src/bootstrap_datepicker_plus/templates/bootstrap_datepicker_plus/input.html
@@ -1,7 +1,7 @@
 <div class="input-group dbdp">
   {% include 'django/forms/widgets/text.html' %}
   <div class="input-group-addon input-group-append input-group-text">
-    <i class="{{ addon_icon_class }}"></i>
+    <i class="{{ widget.addon_icon_class }}"></i>
   </div>
 </div>
 {% if "data-dbdp-debug" in widget.attrs %}


### PR DESCRIPTION
## Purpose
This PR addresses an issue where the picker icons are not showing in the latest version (5.0.5) of `django-bootstrap-datepicker-plus` when using a custom `MultiWidget` input with `DatePickerInput` and `TimePickerInput`. This issue was originally raised [in this GitHub issue](https://github.com/monim67/django-bootstrap-datepicker-plus/issues/119).

## Approach
This change fixes the missing picker icons by adjusting the context returned by `BasePickerInput`. Specifically, it modifies the context dictionary to correctly pass the `addon_icon_class` to the widget template.

#### Issues solved in this PR
- [x] Missing picker icons in custom `MultiWidget` input.

#### What has Changed
- Adjusted `_base.py` to ensure the `addon_icon_class` is passed correctly in the context.
- Updated the `input.html` template to use `widget.addon_icon_class` instead of `addon_icon_class`.
